### PR TITLE
Expand Nexus dashboard metrics and canon links

### DIFF
--- a/VDM_Nexus/TODO_CHECKLIST.md
+++ b/VDM_Nexus/TODO_CHECKLIST.md
@@ -44,6 +44,7 @@ Begin the task by following the instructions below:
 
 - [DONE] Step 0.2.1 — Install Qt 6.5+, CMake ≥3.24, compiler (Clang/MSVC/GCC matching CI targets) with C++20 support. Evidence: CMake configure succeeded; Qt6 6.5 components resolved.
   - Installed Qt 6 base + declarative development packages along with QML runtime modules (QtQuick, Controls, Layouts, Templates, WorkerScript) so the dashboard preview can start inside the container.
+  - Supplemented runtime with Qt 6 QML import packages (`qml6-module-qtquick`, `qml6-module-qtquick-controls`, `qml6-module-qtquick-layouts`, `qml6-module-qtquick-workerscript`, `qml6-module-qtquick-templates`, `qml6-module-qtquick-window`) to unblock offscreen test runs of the dashboard shell.
 - [DONE] Step 0.2.2 — Set up Python 3.13.5 environment with repo `requirements.txt`; enable `poetry`/`pip-tools` lock if applicable. Evidence: Python 3.13.5 active; `pip check` OK.
 - [DONE] Step 0.2.3 — Configure deterministic environment variables (`OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, `BLIS_NUM_THREADS`, `VECLIB_MAXIMUM_THREADS`, `NUMEXPR_NUM_THREADS`, `PYTHONHASHSEED`) per canon execution policy. Evidence: [`VDM_Nexus/.env.example`](VDM_Nexus/.env.example:7) updated; copy to local .env for development shells.
 
@@ -194,6 +195,7 @@ Begin the task by following the instructions below:
 - [STARTED] Step 4.1.1 — Implement Dashboard panes (Active Experiments, Pending Approvals, KPI summaries, orphan proposals).
   - Added QML dashboard preview (`presentation/qml/Main.qml`) wiring `DashboardController` metrics into three-card layout with canon anchor links; loads roadmap index read-only at startup.
   - Packaged dashboard QML into `presentation.qrc` under the `/presentation` prefix and verified the headless Qt Quick runtime loads without missing module errors.
+  - Added headless runtime guard in `main.cpp` that exits automatically when `QT_QPA_PLATFORM=offscreen` after confirming QML load, preventing hung CI sessions.
 - [NOT STARTED] Step 4.1.2 — Develop Artifact browser with filters by domain, tag, gate status, run timestamp.
 - [NOT STARTED] Step 4.1.3 — Implement Proposal/Results Viewer: render PROPOSAL_* and RESULTS_* Markdown with math rendering, commit banners, anchor navigation; read-only.
 - [NOT STARTED] Step 4.1.4 — Implement Experiment Browser (Configs/Specs): list per-domain experiments and open config/spec JSON with a pretty/JSON-path viewer; display repository path and commit hash; read-only (no writes to derivation).

--- a/VDM_Nexus/presentation/qml/DashboardMetrics.qml
+++ b/VDM_Nexus/presentation/qml/DashboardMetrics.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Item {
     id: root

--- a/VDM_Nexus/presentation/qml/Main.qml
+++ b/VDM_Nexus/presentation/qml/Main.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 ApplicationWindow {
     id: root
@@ -9,12 +9,6 @@ ApplicationWindow {
     height: 600
     title: "VDM Nexus — Dashboard Preview"
     color: "#111318"
-
-    Component.onCompleted: {
-        if (dashboardController) {
-            dashboardController.loadIndex("");
-        }
-    }
 
     function openRepoPath(path) {
         if (!dashboardController || !path) {

--- a/VDM_Nexus/src/main.cpp
+++ b/VDM_Nexus/src/main.cpp
@@ -4,6 +4,7 @@
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QString>
+#include <QTimer>
 
 #include "../presentation/DashboardController.h"
 
@@ -48,7 +49,18 @@ int main(int argc, char* argv[]) {
 
   engine.load(url);
   if (engine.rootObjects().isEmpty()) {
+    qCritical().noquote() << "[NEXUS][QML] failed to load" << url;
     return -1;
+  }
+
+  const QString platform = qEnvironmentVariable("QT_QPA_PLATFORM");
+  if (platform.compare(QStringLiteral("offscreen"), Qt::CaseInsensitive) == 0) {
+    QTimer::singleShot(0, &app, [&app]() {
+      qInfo().noquote()
+          << "[NEXUS][QML] offscreen platform detected; exiting after successful"
+             " load";
+      app.quit();
+    });
   }
 
   return app.exec();


### PR DESCRIPTION
## Summary
- extend the DashboardController with roadmap summary fields, spotlight cards, and repository URL helpers so QML can surface canon-aware data.
- refresh the dashboard QML shell to show enriched metric cards, spotlight proposals missing RESULTS bundles, and quick links to AXIOMS/EQUATIONS/VALIDATION anchors.
- record checklist progress for the new dashboard capabilities and log the expanded metrics during startup.

## Testing
- cmake -S VDM_Nexus -B VDM_Nexus/build
- cmake --build VDM_Nexus/build

------
https://chatgpt.com/codex/tasks/task_e_690148835110832693e4015200f011fd

## Summary by Sourcery

Expand the Nexus dashboard by enriching the backend controller with summary fields and reference data, wire up a QML-based dashboard UI for interactive metrics, spotlight cards, and canonical links, and adjust the build configuration and checklists accordingly.

New Features:
- Expose additional summary metrics (total proposals, missing results, results total, code domains, documentation buckets, and last update) and spotlight/reference lists in DashboardController
- Add repositoryUrl helper to resolve document paths against VDM_REPO_ROOT, current directory, or application directory
- Introduce QML dashboard UI (Main.qml and DashboardMetrics.qml) to display enriched metric cards, spotlight proposal sync status, and clickable canonical reference chips

Enhancements:
- Update main.cpp to launch a QQmlApplicationEngine, bind DashboardController to the QML context, and log expanded dashboard metrics at startup

Build:
- Include Qt QuickControls2 and presentation.qrc in CMake configuration for QML resources

Chores:
- Mark progress in TODO_CHECKLISTs to reflect implementation of new dashboard capabilities