### PR TITLE
Implement Task 0.3 canon ingestion scaffolding

### DIFF
--- a/VDM_Nexus/TODO_CHECKLIST.md
+++ b/VDM_Nexus/TODO_CHECKLIST.md
@@ -62,6 +62,7 @@ Begin the task by following the instructions below:
 - [DONE] Step 0.3.2 — Set up repository-relative path resolver for `../derivation/` tree with guard rails against writes. (Note: resolver prints AXIOMS/EQUATIONS/VALIDATION_METRICS + commits.)
   - Implemented `scripts/canon_paths.py` providing guarded resolution, git metadata helpers, and enforced Derivation scoping; updated resolver printer to consume it.
   - Hardened metadata collection against filesystem permission errors and added regression tests covering repo resolution, fragment handling, and escape prevention.
+  - Relaxed canonical resolution to operate in non-strict mode so future canon entries that have not landed yet resolve without raising while remaining read-only; added regression coverage for missing-file lookups.
 - [DONE] Step 0.3.3 — Draft `CanonSync` CLI skeleton (read-only) for future indexing per standards.
   - Added `scripts/nexus_canon_sync.py` to emit read-only plans from the canon config using the shared resolver; documented usage in scripts README.
 

--- a/VDM_Nexus/scripts/canon_paths.py
+++ b/VDM_Nexus/scripts/canon_paths.py
@@ -134,11 +134,11 @@ class CanonResolver:
             raise CanonPathError("Empty canonical path")
 
         path_part, fragment = self._split_fragment(raw)
-        target = Path(path_part)
+        target = Path(path_part).expanduser()
         if target.is_absolute():
-            resolved = target.resolve()
+            resolved = target.resolve(strict=False)
         else:
-            resolved = (self.repo_root / target).resolve()
+            resolved = (self.repo_root / target).resolve(strict=False)
 
         try:
             resolved.relative_to(self.derivation_root)

--- a/VDM_Nexus/scripts/tests/test_canon_paths.py
+++ b/VDM_Nexus/scripts/tests/test_canon_paths.py
@@ -74,3 +74,10 @@ def test_metadata_for_missing_file(resolver):
     assert metadata.sha256 is None
     assert metadata.size_bytes is None
     assert metadata.last_commit is None
+
+
+def test_resolve_missing_file_is_read_only(resolver):
+    target = "Derivation/__does_not_exist__.md#future"
+    path, fragment = resolver.resolve(target)
+    assert path == resolver.repo_root / "Derivation" / "__does_not_exist__.md"
+    assert fragment == "future"


### PR DESCRIPTION
## Summary
- add a read-only canon configuration manifest enumerating required AXIOMS/EQUATIONS/VALIDATION_METRICS anchors
- introduce a shared canon path resolver utility and update the resolver printer to enforce Derivation-only access
- provide a CanonSync CLI skeleton plus documentation describing the new read-only tooling

## Testing
- python VDM_Nexus/scripts/nexus_resolver_print.py --json
- python VDM_Nexus/scripts/nexus_canon_sync.py --json

------
https://chatgpt.com/codex/tasks/task_e_6901b71abdd4832684b7b246c61c93c9

## Summary by Sourcery

Implement scaffolding for Task 0.3 canon ingestion by adding a config manifest, a shared CanonResolver module, updating the resolver printer to enforce read-only Derivation access, and introducing a CLI skeleton for generating read-only ingestion plans.

New Features:
- Add a read-only canon configuration manifest enumerating required AXIOMS, EQUATIONS, and VALIDATION_METRICS anchors
- Introduce canon_paths.py with a CanonResolver utility for safe Derivation-only path resolution and file metadata
- Update nexus_resolver_print.py to use CanonResolver for enforcing Derivation scoping and metadata retrieval
- Provide nexus_canon_sync.py CLI skeleton to emit read-only ingestion plans from the canon config

Enhancements:
- Extend scripts/README.md and resources/README.md with documentation for the new canon ingestion tooling
- Mark Task 0.3 steps as completed in TODO_CHECKLIST.md and describe implemented scaffolding